### PR TITLE
Feature: CRC Error checking mechanism

### DIFF
--- a/include/alice/packet.hpp
+++ b/include/alice/packet.hpp
@@ -21,6 +21,9 @@ namespace alice
         ERROR
     };
 
+    constexpr uint16_t CRC16_POLYNOMIAL = 0x8005;
+    constexpr uint16_t CRC16_INITIAL = 0xFFFF;
+
     class Packet
     {
     public:
@@ -37,11 +40,12 @@ namespace alice
         uint16_t payload_type;
         std::vector<uint8_t> payload;
 
-        Packet(uint32_t source_id, uint32_t destination_id, PacketType type, uint8_t priority, uint32_t sequence_number, const std::vector<uint8_t> &payload);
+        Packet(uint32_t source_id, uint32_t destination_id, PacketType type, uint8_t priority, uint32_t sequence_number, const std::vector<uint8_t> &payload, uint16_t crc);
 
         [[nodiscard]] std::vector<uint8_t> serialize() const;
 
         static Packet deserialize(const std::vector<uint8_t> &buffer);
+        static uint16_t crc16(const std::vector<uint8_t> &buffer);
     };
 
 }

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -10,7 +10,7 @@ namespace alice
 {
     Packet::Packet(uint32_t source_id, uint32_t destination_id, PacketType type, uint8_t priority, uint32_t sequence_number, const std::vector<uint8_t> &payload, uint16_t crc = 0)
         : source_id(source_id), destination_id(destination_id), type(type), priority(priority), sequence_number(sequence_number), timestamp(static_cast<uint64_t>(std::time(nullptr))),
-          payload(payload)
+          payload(payload), crc(crc)
     {
     }
 

--- a/test/test_packet.cpp
+++ b/test/test_packet.cpp
@@ -13,12 +13,14 @@ BOOST_AUTO_TEST_CASE(packet_serialize_deserialize)
     uint8_t priority = 1;
     uint32_t sequence_number = 100;
     std::vector<uint8_t> payload = {10, 20, 30, 40, 50};
+    uint16_t crc = 0;
 
     // Create the original packet
-    alice::Packet original_packet(source_id, destination_id, type, priority, sequence_number, payload);
+    alice::Packet original_packet(source_id, destination_id, type, priority, sequence_number, payload, crc);
 
     // Serialize the packet
     std::vector<uint8_t> serialized_data = original_packet.serialize();
+    uint16_t original_packet_crc = (static_cast<uint16_t>(serialized_data[serialized_data.size() - 2]) << 8) | serialized_data[serialized_data.size() - 1];
 
     // Deserialize the serialized data into a new packet
     alice::Packet deserialized_packet = alice::Packet::deserialize(serialized_data);
@@ -31,4 +33,5 @@ BOOST_AUTO_TEST_CASE(packet_serialize_deserialize)
     BOOST_CHECK_EQUAL(deserialized_packet.sequence_number, original_packet.sequence_number);
     BOOST_CHECK_EQUAL(deserialized_packet.timestamp, original_packet.timestamp);
     BOOST_CHECK(deserialized_packet.payload == original_packet.payload);
+    BOOST_CHECK(deserialized_packet.crc == original_packet_crc);
 }

--- a/test/test_packet.cpp
+++ b/test/test_packet.cpp
@@ -15,17 +15,13 @@ BOOST_AUTO_TEST_CASE(packet_serialize_deserialize)
     std::vector<uint8_t> payload = {10, 20, 30, 40, 50};
     uint16_t crc = 0;
 
-    // Create the original packet
     alice::Packet original_packet(source_id, destination_id, type, priority, sequence_number, payload, crc);
 
-    // Serialize the packet
     std::vector<uint8_t> serialized_data = original_packet.serialize();
     uint16_t original_packet_crc = (static_cast<uint16_t>(serialized_data[serialized_data.size() - 2]) << 8) | serialized_data[serialized_data.size() - 1];
 
-    // Deserialize the serialized data into a new packet
     alice::Packet deserialized_packet = alice::Packet::deserialize(serialized_data);
 
-    // Verify that the deserialized packet matches the original packet
     BOOST_CHECK_EQUAL(deserialized_packet.source_id, original_packet.source_id);
     BOOST_CHECK_EQUAL(deserialized_packet.destination_id, original_packet.destination_id);
     BOOST_CHECK_EQUAL(static_cast<int>(deserialized_packet.type), static_cast<int>(original_packet.type));


### PR DESCRIPTION
1. The initial CRC value will be 0.
2. Calculation of the 16-bit CRC field is done during serialization.
3. After receiving the packet and during the deserialization process, the CRC checksum is validated for the whole buffer.
4. Added CRC assertion in the test suite.