### PR TITLE
feat: add EncryptionManager to perform encrypt/decrypt functionalities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TEST_SOURCES
     test/test_main.cpp
     test/test_example.cpp
     test/test_packet.cpp
+    test/test_encryption_manager.cpp
 )
 
 add_executable(peer_bootstrap_node src/peer_bootstrap_node.cpp)

--- a/include/alice/encryption_manager.hpp
+++ b/include/alice/encryption_manager.hpp
@@ -1,0 +1,31 @@
+//
+// Created by Kaaviya Ramkumar on 14/11/24.
+//
+
+#ifndef ENCRYPTION_MANAGER_H
+#define ENCRYPTION_MANAGER_H
+
+#include <vector>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+
+#include "logger.hpp"
+
+namespace alice {
+    class EncryptionManager {
+    public:
+        static const int CHACHA20_KEY_SIZE = 32;
+        static const int CHACHA20_NONCE_SIZE = 12;
+
+        EncryptionManager();
+
+        std::vector<uint8_t> encrypt(const std::vector<uint8_t>& buffer) const;
+        std::vector<uint8_t> decrypt(const std::vector<uint8_t>& encrypted_buffer) const;
+
+    private:
+        std::vector<uint8_t> key;
+    };
+};
+
+
+#endif //ENCRYPTION_MANAGER_H

--- a/include/alice/packet.hpp
+++ b/include/alice/packet.hpp
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "encryption_manager.hpp"
+
 namespace alice
 {
 
@@ -42,10 +44,12 @@ namespace alice
 
         Packet(uint32_t source_id, uint32_t destination_id, PacketType type, uint8_t priority, uint32_t sequence_number, const std::vector<uint8_t> &payload, uint16_t crc);
 
-        [[nodiscard]] std::vector<uint8_t> serialize() const;
+        [[nodiscard]] std::vector<uint8_t> serialize(const EncryptionManager& encryptor) const;
 
-        static Packet deserialize(const std::vector<uint8_t> &buffer);
+        static Packet deserialize(const std::vector<uint8_t> &buffer, const EncryptionManager& decryptor);
         static uint16_t crc16(const std::vector<uint8_t> &buffer);
+
+
     };
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(alice
         device_meta/eci_position_calculator.cpp
         device_meta/position_table.cpp
         position_service/position_notifier.cpp
+        encryption_manager.cpp
 #        error_handler.cpp
 )
 

--- a/src/encryption_manager.cpp
+++ b/src/encryption_manager.cpp
@@ -1,0 +1,100 @@
+//
+// Created by Kaaviya Ramkumar on 14/11/24.
+//
+
+#include "alice/encryption_manager.hpp"
+
+namespace alice {
+    EncryptionManager::EncryptionManager() {
+        key.resize(CHACHA20_KEY_SIZE);
+        // Generate a secure key for an instance of EncryptionManager
+        RAND_bytes(key.data(), CHACHA20_KEY_SIZE);
+    }
+
+    std::vector<uint8_t> EncryptionManager::encrypt(const std::vector<uint8_t>& buffer) const {
+        EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+        if (!ctx) {
+            Logger::log(LogLevel::ERROR, "Failed to create encryption context");
+            throw std::runtime_error("Failed to create encryption context");
+        }
+
+        std::vector<uint8_t> nonce(CHACHA20_NONCE_SIZE);
+        if (RAND_bytes(nonce.data(), CHACHA20_NONCE_SIZE) != 1) {
+            Logger::log(LogLevel::ERROR, "Failed to generate random nonce");
+            EVP_CIPHER_CTX_free(ctx);
+            throw std::runtime_error("Failed to generate random nonce");
+        }
+
+        std::vector<uint8_t> ciphertext(buffer.size() + CHACHA20_NONCE_SIZE);
+
+        int len = 0;
+        int ciphertext_len = 0;
+
+        if (EVP_EncryptInit_ex(ctx, EVP_chacha20(), nullptr, key.data(), nonce.data()) != 1) {
+            Logger::log(LogLevel::ERROR, "Failed to initialize encryption");
+            EVP_CIPHER_CTX_free(ctx);
+            throw std::runtime_error("Failed to initialize encryption");
+        }
+
+        if (EVP_EncryptUpdate(ctx, ciphertext.data(), &len, buffer.data(), buffer.size()) != 1) {
+            Logger::log(LogLevel::ERROR, "Failed during update encryption");
+            EVP_CIPHER_CTX_free(ctx);
+            throw std::runtime_error("Failed during update encryption");
+        }
+        ciphertext_len = len;
+
+        if (EVP_EncryptFinal_ex(ctx, ciphertext.data() + len, &len) != 1) {
+            Logger::log(LogLevel::ERROR, "Failed during final encryption");
+            EVP_CIPHER_CTX_free(ctx);
+            throw std::runtime_error("Failed during final encryption");
+        }
+        ciphertext_len += len;
+
+        EVP_CIPHER_CTX_free(ctx);
+
+        ciphertext.insert(ciphertext.begin(), nonce.begin(), nonce.end());
+        ciphertext.resize(ciphertext_len + CHACHA20_NONCE_SIZE);
+
+        return ciphertext;
+    }
+
+    std::vector<uint8_t> EncryptionManager::decrypt(const std::vector<uint8_t>& encrypted_buffer) const {
+        if (encrypted_buffer.size() < CHACHA20_NONCE_SIZE) {
+            Logger::log(LogLevel::ERROR, "Invalid ciphertext size");
+            throw std::runtime_error("Invalid ciphertext size");
+        }
+
+        EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+        if (!ctx) {
+            Logger::log(LogLevel::ERROR, "Failed to create encryption context");
+            throw std::runtime_error("Failed to create encryption context");
+        }
+
+        std::vector<uint8_t> nonce(encrypted_buffer.begin(), encrypted_buffer.begin() + CHACHA20_NONCE_SIZE);
+        std::vector<uint8_t> ciphertext(encrypted_buffer.begin() + CHACHA20_NONCE_SIZE, encrypted_buffer.end());
+        std::vector<uint8_t> decrypted_data(ciphertext.size());
+
+        int len;
+        int decrypted_len;
+
+        EVP_DecryptInit_ex(ctx, EVP_chacha20(), nullptr, key.data(), nonce.data());
+        if (EVP_DecryptUpdate(ctx, decrypted_data.data(), &len, ciphertext.data(), ciphertext.size()) != 1) {
+            Logger::log(LogLevel::ERROR, "Failed during update decryption");
+            EVP_CIPHER_CTX_free(ctx);
+            throw std::runtime_error("Failed during update decryption");
+        }
+        decrypted_len = len;
+
+        if (EVP_DecryptFinal_ex(ctx, decrypted_data.data() + len, &len) != 1) {
+            Logger::log(LogLevel::ERROR, "Failed during final decryption");
+            EVP_CIPHER_CTX_free(ctx);
+            throw std::runtime_error("Failed during final decryption");
+        }
+        decrypted_len += len;
+
+        decrypted_data.resize(decrypted_len);
+        EVP_CIPHER_CTX_free(ctx);
+
+        return decrypted_data;
+    }
+};

--- a/test/test_encryption_manager.cpp
+++ b/test/test_encryption_manager.cpp
@@ -1,0 +1,54 @@
+// test/test_encryption_manager.cpp
+
+#include <boost/test/unit_test.hpp>
+#include <alice/encryption_manager.hpp>
+#include <vector>
+#include <stdexcept>
+
+BOOST_AUTO_TEST_CASE(encryption_manager_encrypt_decrypt)
+{
+    alice::EncryptionManager encryptor;
+
+    std::vector<uint8_t> original_data = {10, 20, 30, 40, 50};
+
+    std::vector<uint8_t> encrypted_data = encryptor.encrypt(original_data);
+
+    // Ensure the encrypted data is not the same as the original (basic check)
+    BOOST_CHECK(encrypted_data != original_data);
+
+    std::vector<uint8_t> decrypted_data = encryptor.decrypt(encrypted_data);
+
+    BOOST_CHECK(decrypted_data == original_data);
+}
+
+BOOST_AUTO_TEST_CASE(encryption_manager_different_ciphertexts)
+{
+    alice::EncryptionManager encryptor;
+
+    std::vector<uint8_t> original_data = {10, 20, 30, 40, 50};
+
+    std::vector<uint8_t> encrypted_data1 = encryptor.encrypt(original_data);
+    std::vector<uint8_t> encrypted_data2 = encryptor.encrypt(original_data);
+
+    // Verify that the two ciphertexts are different due to unique nonces
+    BOOST_CHECK(encrypted_data1 != encrypted_data2);
+
+    std::vector<uint8_t> decrypted_data1 = encryptor.decrypt(encrypted_data1);
+    std::vector<uint8_t> decrypted_data2 = encryptor.decrypt(encrypted_data2);
+
+    BOOST_CHECK(decrypted_data1 == original_data);
+    BOOST_CHECK(decrypted_data2 == original_data);
+}
+
+BOOST_AUTO_TEST_CASE(encryption_manager_invalid_decryption)
+{
+    alice::EncryptionManager encryptor;
+
+    std::vector<uint8_t> original_data = {10, 20, 30, 40, 50};
+    std::vector<uint8_t> encrypted_data = encryptor.encrypt(original_data);
+
+    // Modify the encrypted data by flipping bits to simulate corruption
+    encrypted_data[0] ^= 0xFF;
+
+    BOOST_CHECK_THROW(encryptor.decrypt(encrypted_data), std::runtime_error);
+}


### PR DESCRIPTION
1. Added EncryptionManager class for ChaCha20 encryption/decryption (OpenSSL 1.1.1f on the pi supports this).
2. Implemented secure key generation in constructor - key is randomly generated once per instance of EncryptionManager.
3. Generates a unique random nonce for each encryption to ensure different ciphertexts, even for identical plaintexts.
4. Added error checks and logs for all stages of encryption and decryption performed through OpenSSL APIs.
5. Threw exceptions (and added to the logger) for failed operations to handle any corrupted data gracefully.
6. Added some unit test cases for encryption and decryption.